### PR TITLE
Fixes Factory.podspec xcprivacy clash

### DIFF
--- a/Factory.podspec
+++ b/Factory.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = "Michael Long"
   s.source       = { :git => "https://github.com/hmlongco/Factory.git", :tag => "#{s.version}" }
   s.source_files  = "Sources/**/*.swift"
-  s.resources     = "Sources/**/*.xcprivacy"
+  s.resource_bundles = { "Factory" => "Sources/**/*.xcprivacy" }
   s.swift_version = '5.9'
 
   s.ios.deployment_target = "12.0"


### PR DESCRIPTION
Changed the inclusion of PrivacyInfo.xcprivacy to resource_bundles for cocoapod to avoid resource name collision when the user uses cocoapod as static library.